### PR TITLE
feat: support ws extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
 					"warpscript"
 				],
 				"extensions": [
-					"mc2"
+					"mc2",
+					"ws"
 				],
 				"configuration": "./client/syntaxes/language-configuration.json"
 			}


### PR DESCRIPTION
mc2 extension is a legacy thing on Warp10-platform inspired from Einstein language.
Some of us already use new one: ws 

We can easily support both of them :-)
