### PR TITLE
Addglobalonselectionshortcut

### DIFF
--- a/client/src/providers/wsImagebase64Provider.ts
+++ b/client/src/providers/wsImagebase64Provider.ts
@@ -27,6 +27,10 @@ export default class WSImagebase64Provider implements vscode.TextDocumentContent
             border-style: dashed;
             border-color: red;
             border-width: 1px;
+            background-color: #fff;
+            background-image: linear-gradient(45deg,#efefef 25%,transparent 25%,transparent 75%,#efefef 75%,#efefef),linear-gradient(45deg,#efefef 25%,transparent 25%,transparent 75%,#efefef 75%,#efefef);
+            background-position: 0 0,10px 10px;
+            background-size: 21px 21px;        
         }
         
         </style>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
 				"command": "extension.execWS",
 				"key": "ctrl+alt+e",
 				"when": "editorFocus && !replaceActive && !searchViewletVisible && !findWidgetVisible"
+			},
+			{
+				"command": "extension.execWSOnSelection",
+				"key": "ctrl+alt+a",
+				"when": "editorHasSelection && editorFocus && !replaceActive && !searchViewletVisible && !findWidgetVisible"
 			}
 		],
 		"commands": [
@@ -52,7 +57,12 @@
 					"light": "./image/run.svg",
 					"dark": "./image/run_inverse.svg"
 				}
+			},
+			{
+				"command": "extension.execWSOnSelection",
+				"title": "Run Warpscript on selection"
 			}
+
 		],
 		"languages": [
 			{


### PR DESCRIPTION
ctrl shift a was not defined in root package.json, so not functional outside debug environment.
