### PR TITLE
Local macro substitution deactivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ More details on [warp10.io](http://www.warp10.io)
   - [EXEC_START_DATE] file:///os_temp_dir/executed_warpscript.mc2 => file:///os_temp_dir/result.json exec_time fetched_data op_count main_filename.mc2
   - [EXEC_START_DATE] ERROR /path/to/script/in/error.mc2:error_line reason_of_failure
 - WarpScript and resulting JSON are sent gzipped between the client and the server
+- // @endpoint http://xxx/api/v0/exec at the beginning of the script change the remote execution endpoint
+- // @localmacrosubstitution false at the beginning of the script deactivate the local macro substitution
 
 ## How to run
 

--- a/src/features/execCommand.ts
+++ b/src/features/execCommand.ts
@@ -30,7 +30,9 @@ export default class ExecCommand {
                 title: 'Executing ' + baseFilename + ' on ' + Warp10URL
             }, (progress: vscode.Progress<{ message?: string; }>) => {
                 return new Promise(async (c, e) => {
-                    let executedWarpScript="";
+                    let executedWarpScript = "";
+                    let substitutionWithLocalMacros = true;
+
                     if(selectiontext === "" ) {
                         executedWarpScript = document.getText(); //if executed with empty string, take the full text
                     }
@@ -57,6 +59,10 @@ export default class ExecCommand {
                                     case "endpoint":        //        // @endpoint http://mywarp10server/api/v0/exec
                                         Warp10URL = parametervalue;   // overrides the Warp10URL configuration
                                         console.log(Warp10URL);
+                                        break;
+                                    case "localmacrosubstitution":    
+                                        substitutionWithLocalMacros = ("true" === parametervalue.toLowerCase());   // overrides the substitutionWithLocalMacros
+                                        console.log("substitutionWithLocalMacros="+substitutionWithLocalMacros);
                                         break;
                                 
                                     default:
@@ -88,7 +94,7 @@ export default class ExecCommand {
                     let lines: number[] = [document.lineCount]
                     let uris: string[] = [document.uri.toString()]
 
-                    while ((match = macroPattern.exec(executedWarpScript))) {
+                    while (substitutionWithLocalMacros && (match = macroPattern.exec(executedWarpScript))) {
                         const macroName = match[1];
                         await WSDocumentLinksProvider.getMacroURI(macroName).then(
                             async (uri) => {


### PR DESCRIPTION
"// @localmacrosubstitution false" at the beginning of the script deactivate the local macro substitution

README updated.